### PR TITLE
fix : 랜덤 게임 뷰, 병호 메시지 뷰 수정

### DIFF
--- a/Gabwatni_Cave/Gabwatni_Cave/DarkZone/Abyss/Abyss.swift
+++ b/Gabwatni_Cave/Gabwatni_Cave/DarkZone/Abyss/Abyss.swift
@@ -15,7 +15,7 @@ struct Abyss: View {
     
     @State var isBoss: Bool = false
     
-    @State var isTouchable: Bool = false
+    @State var isTouchable: Bool = true
     
     let size = UIScreen.main.bounds
     
@@ -33,6 +33,8 @@ struct Abyss: View {
     @State private var inputString = ""
     @State private var textEnd: Bool = false
     
+    @State private var isblurView: Bool = false
+    
     var body: some View {
         if abyssView {
             ZStack {
@@ -42,18 +44,19 @@ struct Abyss: View {
                     .scaledToFit()
                     .ignoresSafeArea()
                 
+            
                 if !vm.isBossTalk && (!presentView || !abyssView) {
                     LightView()
                         .onAppear{
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                                 if vm.itemDict["water"]! && vm.itemDict["cavecoral"]! {
-                                    //
+                                    isTouchable = false
                                     playSoundEffect(sound: "bossSound1", type: ".mp3")
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 2){
-                                        withAnimation(.easeIn(duration: 1.5)){
-                                            
+                                        withAnimation(.easeIn(duration: 1.1)){
                                             isBoss = true
                                             playSound(sound: "Action_Hero", type: ".mp3")
+                                          
                                         }
                                     }
                                     
@@ -61,6 +64,7 @@ struct Abyss: View {
                                 }
                             }
                         }
+                        .allowsHitTesting(isTouchable)
                     
                     Image("mapIcon")
                         .resizable()
@@ -84,12 +88,6 @@ struct Abyss: View {
                 }
                 
                 
-                
-                //                LightItemView(thisPositionX: 50, thisPositionY: 300, thisFrameWidth: 30, thisFrameHeight: 30, isShowing: $presentView, imageName: "circle", showingImage: "water")
-                //
-                //                LightItemView(thisPositionX: -75, thisPositionY: -200, thisFrameWidth: 30, thisFrameHeight: 30, isShowing: $presentView, imageName: "circle", showingImage: "cavecoral")
-                
-                
                 if presentView && !vm.isBossTalk{
                     CardView(imageName: vm.imageName, cardState: $presentView)
                         .onDisappear {
@@ -97,33 +95,38 @@ struct Abyss: View {
                         }
                 }
                 else if vm.isBossTalk {
-                    Rectangle()
-                        .foregroundColor(.black)
-                        .ignoresSafeArea()
-                    
-                    Image("choi byung-ho")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 300, height: 300)
-                        .offset(y: -80)
-                        .onTapGesture {
-                            vm.isBossTalk = false
-                        }
-                    
-                    textBox(name: "병호쿤", text: inputString)
-                        .onAppear {
-                            talkOnTextBox(stringArray: textArray2, inputIndex: 0)
-                        }
-                        .onDisappear {
-                            vm.itemDict["cavecoral"] = true
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                                isTouchable.toggle()
+                    Group {
+                        Rectangle()
+                            .foregroundColor(.black)
+                            .ignoresSafeArea()
+                        
+                        Image("choi byung-ho")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 300, height: 300)
+                            .offset(y: -80)
+                            .onTapGesture {
+                                vm.isBossTalk = false
                             }
-                        }
+                        
+                        textBox(name: "최병호", text: inputString)
+                            .onAppear {
+                                talkOnTextBox(stringArray: textArray2, inputIndex: 0)
+                            }
+                            .onDisappear {
+                                vm.itemDict["cavecoral"] = true
+                            }
+                    }.onTapGesture {
+                        vm.isBossTalk = false
+                    }
+                    
                 }
                 
                 QuizView(quizModel: QuizModel())
                     .opacity(isBoss ? 1 : 0)
+                    .onChange(of: isBoss) { V in
+                        isTouchable = true
+                    }
                     .allowsHitTesting(isTouchable)
                 
                 // 진입하면 나오는 view


### PR DESCRIPTION
### 수정사항

- 어비스 뷰에서 최병호 이미지만 누르면 꺼지던걸 어디든 누르면 꺼지는 걸로 변경
- 보스가 등장하기 직전 클릭을 최대한 방지 (움직임을 제한함)

### 문제사항

랜덤 문제의 답변 부분을 나오기도 전에 계속 갈기고 있으면 바로 클릭을 인식하는 점

이는 근데 당연히 애니메이션을 사용하여서 어쩔 수 없다고 생각함. (그리고 갈기면 당연히 인식 될 듯)
만약에 애니메이션이 끝나고 터치가 가능하게 바꾸게 구현을 하면, 
터치 가능 유무를 담당하는 bool 값을 바꿔야 하므로 화면이 새로고침 되면서
문제가 멋대로 바뀌는 현상이 생김 (기존 문제에서 시간차를 두므로 누르지도 않았는데 문제가 변경됨)

개인적으로는 이 부분은 냅둬야 한다고 생각함다